### PR TITLE
Add support for single quotes in templates

### DIFF
--- a/syntaxes/vue.tmLanguage.json
+++ b/syntaxes/vue.tmLanguage.json
@@ -123,7 +123,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:template))\\b(?=[^>]*lang=\"slm(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:template))\\b(?=[^>]*lang=[\"']slm(?:\\?[^\"]*)?[\"'])",
       "captures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -158,7 +158,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:template))\\b(?=[^>]*lang=\"jade(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:template))\\b(?=[^>]*lang=[\"']jade(?:\\?[^\"]*)?[\"'])",
       "captures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -193,7 +193,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:template))\\b(?=[^>]*lang=\"pug(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:template))\\b(?=[^>]*lang=[\"']pug(?:\\?[^\"]*)?[\"'])",
       "captures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -228,7 +228,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=\"stylus(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=[\"']stylus(?:\\?[^\"]*)?[\"'])",
       "captures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -263,7 +263,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=\"postcss(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=[\"']postcss(?:\\?[^\"]*)?[\"'])",
       "captures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -298,7 +298,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=\"(?:scss)(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=[\"'](?:scss)(?:\\?[^\"]*)?[\"'])",
       "captures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -333,7 +333,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=\"(?:sass)(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=[\"'](?:sass)(?:\\?[^\"]*)?[\"'])",
       "captures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -368,7 +368,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=\"less(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:style))\\b(?=[^>]*lang=[\"']less(?:\\?[^\"]*)?[\"'])",
       "captures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -438,7 +438,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:script))\\b(?=[^>]*lang=\"coffee(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:script))\\b(?=[^>]*lang=[\"']coffee(?:\\?[^\"]*)?[\"'])",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"
@@ -478,7 +478,7 @@
       ]
     },
     {
-      "begin": "(?:^\\s+)?(<)((?i:script))\\b(?=[^>]*lang=\"livescript(?:\\?[^\"]*)?\")",
+      "begin": "(?:^\\s+)?(<)((?i:script))\\b(?=[^>]*lang=[\"']livescript(?:\\?[^\"]*)?[\"'])",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.tag.begin.html"


### PR DESCRIPTION
## Description
Currently templates are only supported if they use double quotes e.g `<template lang="pug">`. 

## Solution
This updates regex to allow for single quote versions to also be found, e.g `<template lang='pug'>`.